### PR TITLE
Feature/ 등급관리 페이지 구현

### DIFF
--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/BookClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/BookClient.java
@@ -51,12 +51,14 @@ public interface BookClient {
 
     /// 도서등록
     @PostMapping(value = "/api/admin/books", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    Long createBook(@RequestPart("book") BookSaveRequest request,
+    Long createBook(@RequestHeader("Authorization") String accessToken,
+                    @RequestPart("book") BookSaveRequest request,
                     @RequestPart(value = "images", required = false) List<MultipartFile> images);
 
     /// 도서 수정
     @PutMapping(value = "/api/books/{bookId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    void updateBook(@PathVariable("bookId") Long bookId,
+    void updateBook(@RequestHeader("Authorization") String accessToken,
+                    @PathVariable("bookId") Long bookId,
                     @RequestPart("book") BookUpdateRequest request,
                     @RequestPart(value = "images", required = false) List<MultipartFile> images);
 
@@ -70,11 +72,12 @@ public interface BookClient {
 
     /// 도서 삭제
     @DeleteMapping("/api/books/{bookId}")
-    void deleteBook(@PathVariable Long bookId);
+    void deleteBook(@RequestHeader("Authorization") String accessToken, @PathVariable Long bookId);
 
     /// 도서 상태 변경
     @PatchMapping("/api/books/{bookId}/status")
-    void updateBookStatus(@PathVariable Long bookId, @RequestBody BookStatusUpdateRequest req);
+    void updateBookStatus(@RequestHeader("Authorization") String accessToken, @PathVariable Long bookId,
+                          @RequestBody BookStatusUpdateRequest req);
 
     /// 도서 최근 본 상품 조회
     @GetMapping("/api/books/recent-views")
@@ -87,7 +90,8 @@ public interface BookClient {
 
     /// 좋아요 토글 요청
     @PostMapping("/api/books/{bookId}/likes")
-    BookLikeToggleResponse toggleLike(@PathVariable("bookId") Long bookId);
+    BookLikeToggleResponse toggleLike(@RequestHeader("Authorization") String accessToken,
+                                      @PathVariable("bookId") Long bookId);
 
     /// 북 검색엔진
     @GetMapping("/api/books/search")

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/CouponClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/CouponClient.java
@@ -11,21 +11,22 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "gateway-service", contextId = "couponClient", url = "${gateway.base-url}")
 public interface CouponClient {
 
     @PostMapping("/api/admin/coupons")
-    void createCoupon(@RequestBody CouponCreateDto requestDto);
+    void createCoupon(@RequestHeader("Authorization") String accessToken, @RequestBody CouponCreateDto requestDto);
 
     @GetMapping("/api/admin/coupons")
-    Page<CouponDto> getCoupons(@RequestParam("page") int page,
+    Page<CouponDto> getCoupons(@RequestHeader("Authorization") String accessToken, @RequestParam("page") int page,
                                @RequestParam("size") int size,
-                               @RequestParam(value = "status",required = false) String status);
+                               @RequestParam(value = "status", required = false) String status);
 
     @PutMapping("/api/admin/coupons/{couponId}")
-    void updateCouponQuantity(@PathVariable Long couponId,
+    void updateCouponQuantity(@RequestHeader("Authorization") String accessToken, @PathVariable Long couponId,
                               @RequestBody CouponUpdateDto updateDto);
 
     @GetMapping("/api/coupons/appliable")
@@ -33,5 +34,5 @@ public interface CouponClient {
                                   @RequestParam("categoryIds") List<Long> categoryIds);
 
     @PostMapping("/api/coupons/{couponId}/issue")
-    void issueCoupon(@PathVariable("couponId") Long couponId);
+    void issueCoupon(@RequestHeader("Authorization") String accessToken, @PathVariable("couponId") Long couponId);
 }

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/CouponPolicyClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/CouponPolicyClient.java
@@ -7,15 +7,23 @@ import com.nhnacademy.book2onandonfrontservice.dto.couponPolicyDto.enums.CouponP
 import com.nhnacademy.book2onandonfrontservice.dto.couponPolicyDto.enums.CouponPolicyType;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 
 @FeignClient(name = "gateway-service", contextId = "couponPolicyClient", url = "${gateway.base-url}")
 public interface CouponPolicyClient {
 
-    //정책 목록 조회 (페이징)
+    // 정책 목록 조회 (페이징)
     @GetMapping("/api/admin/coupon-policies")
-    Page<CouponPolicyDto> getPolicies(@RequestParam("page") int page,
+    Page<CouponPolicyDto> getPolicies(@RequestHeader("Authorization") String accessToken,
+                                      @RequestParam("page") int page,
                                       @RequestParam("size") int size,
                                       @RequestParam(value = "type", required = false) CouponPolicyType type,
                                       @RequestParam(value = "discountType", required = false) CouponPolicyDiscountType discountType,
@@ -24,21 +32,25 @@ public interface CouponPolicyClient {
 
     // 정책 상세 조회 (단건)
     @GetMapping("/api/admin/coupon-policies/{couponPolicyId}")
-    CouponPolicyDto getPolicy(@PathVariable("couponPolicyId") Long couponPolicyId);
+    CouponPolicyDto getPolicy(@RequestHeader("Authorization") String accessToken,
+                              @PathVariable("couponPolicyId") Long couponPolicyId);
 
 
-    //정책 생성
+    // 정책 생성
     @PostMapping("/api/admin/coupon-policies")
-    void createPolicy(@RequestBody CouponPolicyUpdateDto requestDto);
+    void createPolicy(@RequestHeader("Authorization") String accessToken,
+                      @RequestBody CouponPolicyUpdateDto requestDto);
 
 
     // 정책 수정
     @PutMapping("/api/admin/coupon-policies/{couponPolicyId}")
-    void updatePolicy(@PathVariable("couponPolicyId") Long couponPolicyId,
+    void updatePolicy(@RequestHeader("Authorization") String accessToken,
+                      @PathVariable("couponPolicyId") Long couponPolicyId,
                       @RequestBody CouponPolicyUpdateDto requestDto);
 
     // 정책 비활성화 (삭제)
     @DeleteMapping("/api/admin/coupon-policies/{couponPolicyId}")
-    void deactivatePolicy(@PathVariable("couponPolicyId") Long couponPolicyId);
+    void deactivatePolicy(@RequestHeader("Authorization") String accessToken,
+                          @PathVariable("couponPolicyId") Long couponPolicyId);
 
 }

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/DeliveryClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/DeliveryClient.java
@@ -5,29 +5,38 @@ import com.nhnacademy.book2onandonfrontservice.dto.deliveryDto.DeliveryWaybillUp
 import com.nhnacademy.book2onandonfrontservice.dto.orderDto.OrderStatus;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "gateway-service", contextId = "deliveryClient", url = "${gateway.base-url}")
 public interface DeliveryClient {
 
     //주문 번호로 배송정보 조회
     @GetMapping("/api/deliveries")
-    DeliveryDto getDeliveryByOrder(@RequestParam("orderId") Long orderId, @RequestHeader("Authorization") String accessToken);
+    DeliveryDto getDeliveryByOrder(@RequestParam("orderId") Long orderId,
+                                   @RequestHeader("Authorization") String accessToken);
 
 
     // admin 배송 목록 조회 (페이징 + 상태 필터링)
     @GetMapping("/api/admin/deliveries")
-    Page<DeliveryDto> getDeliveries(@RequestParam("page") int page,
-                                            @RequestParam("size") int size,
-                                            @RequestParam(value = "status", required = false) OrderStatus status);
+    Page<DeliveryDto> getDeliveries(@RequestHeader("Authorization") String accessToken,
+                                    @RequestParam("page") int page,
+                                    @RequestParam("size") int size,
+                                    @RequestParam(value = "status", required = false) OrderStatus status);
 
-     // admin 운송장 등록 (배송 시작)
+    // admin 운송장 등록 (배송 시작)
     @PutMapping("/api/admin/deliveries/{deliveryId}/waybill")
-    void registerWaybill(@PathVariable("deliveryId") Long deliveryId,
+    void registerWaybill(@RequestHeader("Authorization") String accessToken,
+                         @PathVariable("deliveryId") Long deliveryId,
                          @RequestBody DeliveryWaybillUpdateDto requestDto);
 
     // admin 배송 정보 수정
     @PutMapping("/api/admin/deliveries/{deliveryId}/info")
-    void updateDeliveryInfo(@PathVariable("deliveryId") Long deliveryId,
+    void updateDeliveryInfo(@RequestHeader("Authorization") String accessToken,
+                            @PathVariable("deliveryId") Long deliveryId,
                             @RequestBody DeliveryWaybillUpdateDto requestDto);
 }

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/DeliveryPolicyClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/DeliveryPolicyClient.java
@@ -8,23 +8,28 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @FeignClient(name = "gateway-service", contextId = "deliveryPolicyClient", url = "${gateway.base-url}")
 public interface DeliveryPolicyClient {
 
     @GetMapping("/api/admin/delivery-policies")
-    Page<DeliveryPolicyDto> getDeliveryPolicies(@RequestParam("page") int page,
+    Page<DeliveryPolicyDto> getDeliveryPolicies(@RequestHeader("Authorization") String accessToken,
+                                                @RequestParam("page") int page,
                                                 @RequestParam("size") int size);
 
     @GetMapping("/api/admin/delivery-policies/{deliveryPolicyId}")
-    DeliveryPolicyDto getDeliveryPolicy(@PathVariable("deliveryPolicyId") Long deliveryPolicyId);
+    DeliveryPolicyDto getDeliveryPolicy(@RequestHeader("Authorization") String accessToken,
+                                        @PathVariable("deliveryPolicyId") Long deliveryPolicyId);
 
 
     @PostMapping("/api/admin/delivery-policies")
-    void createDeliveryPolicy(@RequestBody DeliveryPolicyDto requestDto);
+    void createDeliveryPolicy(@RequestHeader("Authorization") String accessToken,
+                              @RequestBody DeliveryPolicyDto requestDto);
 
     @PutMapping("/api/admin/delivery-policies/{deliveryPolicyId}")
-    void updateDeliveryPolicy(@PathVariable("deliveryPolicyId") Long deliveryPolicyId,
-                             @RequestBody DeliveryPolicyDto requestDto);
+    void updateDeliveryPolicy(@RequestHeader("Authorization") String accessToken,
+                              @PathVariable("deliveryPolicyId") Long deliveryPolicyId,
+                              @RequestBody DeliveryPolicyDto requestDto);
 }

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/UserGradeClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/UserGradeClient.java
@@ -9,20 +9,22 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 @FeignClient(name = "gateway-service", contextId = "userGradeClient", url = "${gateway.base-url}")
 public interface UserGradeClient {
     // 전체 등급 조회
     @GetMapping("/api/admin/grades")
-    List<UserGradeDto> getAllGrades();
+    List<UserGradeDto> getAllGrades(@RequestHeader("Authorization") String accessToken);
 
     // 등급 생성
     @PostMapping("/api/admin/grades")
-    void createGrade(@RequestBody UserGradeRequestDto request);
+    void createGrade(@RequestHeader("Authorization") String accessToken, @RequestBody UserGradeRequestDto request);
 
     // 등급 수정
     @PutMapping("/api/admin/grades/{gradeId}")
-    void updateGrade(@PathVariable("gradeId") Long gradeId, @RequestBody UserGradeRequestDto request);
+    void updateGrade(@RequestHeader("Authorization") String accessToken, @PathVariable("gradeId") Long gradeId,
+                     @RequestBody UserGradeRequestDto request);
 
 
 }

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/adminController/AdminViewController.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/adminController/AdminViewController.java
@@ -151,12 +151,14 @@ public class AdminViewController {
     }
 
     @GetMapping("/coupons")
-    public String listCoupons(@RequestParam(defaultValue = "0") int page,
+    public String listCoupons(HttpServletRequest request,
+                              @RequestParam(defaultValue = "0") int page,
                               @RequestParam(defaultValue = "10") int size,
                               @RequestParam(required = false) String status,
                               Model model) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
 
-        Page<CouponDto> couponPage = couponClient.getCoupons(page, size, status);
+        Page<CouponDto> couponPage = couponClient.getCoupons(token, page, size, status);
 
         model.addAttribute("coupons", couponPage.getContent());
         model.addAttribute("currentPage", page);
@@ -168,11 +170,13 @@ public class AdminViewController {
     }
 
     @PostMapping("/coupons/{couponId}/update-quantity")
-    public String updateQuantity(@PathVariable("couponId") Long couponId,
+    public String updateQuantity(HttpServletRequest request,
+                                 @PathVariable("couponId") Long couponId,
                                  @RequestParam(required = false) Integer quantity) {
 
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
         CouponUpdateDto updateDto = new CouponUpdateDto(quantity);
-        couponClient.updateCouponQuantity(couponId, updateDto);
+        couponClient.updateCouponQuantity(token, couponId, updateDto);
 
         return "redirect:/admin/coupons";
     }
@@ -181,9 +185,11 @@ public class AdminViewController {
 
     /// 도서 등록
     @PostMapping("/books/create")
-    public String createBook(@ModelAttribute BookSaveRequest req,
+    public String createBook(HttpServletRequest request, @ModelAttribute BookSaveRequest req,
                              @RequestParam(value = "images", required = false) List<MultipartFile> images) {
-        bookClient.createBook(req, images);
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
+
+        bookClient.createBook(token, req, images);
         return "redirect:/admin/books";
     }
 
@@ -198,61 +204,75 @@ public class AdminViewController {
 
     /// 도서 수정
     @PutMapping("/books/{bookId}")
-    public String updateBook(@ModelAttribute BookUpdateRequest req,
+    public String updateBook(HttpServletRequest request,
+                             @ModelAttribute BookUpdateRequest req,
                              @PathVariable Long bookId,
                              @RequestParam(value = "images", required = false) List<MultipartFile> images) {
-        bookClient.updateBook(bookId, req, images);
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
+        bookClient.updateBook(token, bookId, req, images);
         return "redirect:/admin/books";
     }
 
     /// 도서 삭제
     @DeleteMapping("/books/{bookId}")
-    public String deleteBook(@PathVariable Long bookId) {
-        bookClient.deleteBook(bookId);
+    public String deleteBook(HttpServletRequest request,
+                             @PathVariable Long bookId) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
+        bookClient.deleteBook(token, bookId);
         return "redirect:/admin/books";
     }
 
     /// 도서 상태변경
     @PatchMapping("/books/{bookId}/status")
-    public String updateStatus(@PathVariable Long bookId, @RequestParam("status") BookStatus status) {
+    public String updateStatus(HttpServletRequest req, @PathVariable Long bookId,
+                               @RequestParam("status") BookStatus status) {
         BookStatusUpdateRequest request = new BookStatusUpdateRequest(status);
+        String token = "Bearer " + CookieUtils.getCookieValue(req, "accessToken");
 
-        bookClient.updateBookStatus(bookId, request);
+        bookClient.updateBookStatus(token, bookId, request);
 
         return "redirect:/admin/books";
     }
 
+    ///  -------------------------- Grades Admin --------------------------------------
+
     // 등급 목록 조회 페이지
     @GetMapping("/grades")
-    public String gradeList(Model model) {
-        List<UserGradeDto> grades = userGradeClient.getAllGrades();
+    public String gradeList(HttpServletRequest request, Model model) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
+        List<UserGradeDto> grades = userGradeClient.getAllGrades(token);
         model.addAttribute("grades", grades);
         return "admin/grades/list";
     }
 
     // 새 등급 생성
     @PostMapping("/grades")
-    public String createGrade(@ModelAttribute UserGradeRequestDto request) {
-        userGradeClient.createGrade(request);
+    public String createGrade(HttpServletRequest req, @ModelAttribute UserGradeRequestDto request) {
+        String token = "Bearer " + CookieUtils.getCookieValue(req, "accessToken");
+        userGradeClient.createGrade(token, request);
         return "redirect:/admin/grades";
     }
 
     // 등급 정보 수정
     @PostMapping("/grades/{gradeId}/update")
-    public String updateGrade(@PathVariable Long gradeId, @ModelAttribute UserGradeRequestDto request) {
-        userGradeClient.updateGrade(gradeId, request);
+    public String updateGrade(HttpServletRequest req, @PathVariable Long gradeId,
+                              @ModelAttribute UserGradeRequestDto request) {
+        String token = "Bearer " + CookieUtils.getCookieValue(req, "accessToken");
+        userGradeClient.updateGrade(token, gradeId, request);
         return "redirect:/admin/grades";
     }
 
     ///  -------------------------- Deliveries Admin --------------------------------------
 
     @GetMapping("/deliveries")
-    public String listDeliveries(@RequestParam(defaultValue = "0") int page,
+    public String listDeliveries(HttpServletRequest request,
+                                 @RequestParam(defaultValue = "0") int page,
                                  @RequestParam(defaultValue = "10") int size,
                                  @RequestParam(required = false) OrderStatus status,
                                  Model model) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
 
-        Page<DeliveryDto> deliveryPage = deliveryClient.getDeliveries(page, size, status);
+        Page<DeliveryDto> deliveryPage = deliveryClient.getDeliveries(token, page, size, status);
         log.info("배송: {}", deliveryPage.getTotalElements());
         model.addAttribute("deliveries", deliveryPage.getContent());
         model.addAttribute("currentPage", page);
@@ -274,10 +294,12 @@ public class AdminViewController {
 
     //운송장 등록 처리 (배송 시작)
     @PostMapping("/deliveries/{deliveryId}/waybill")
-    public String registerWaybill(@PathVariable Long deliveryId,
+    public String registerWaybill(HttpServletRequest request,
+                                  @PathVariable Long deliveryId,
                                   @ModelAttribute DeliveryWaybillUpdateDto requestDto) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
 
-        deliveryClient.registerWaybill(deliveryId, requestDto);
+        deliveryClient.registerWaybill(token, deliveryId, requestDto);
 
         return "redirect:/admin/deliveries?status=PREPARING";
     }
@@ -285,19 +307,24 @@ public class AdminViewController {
 
     //운송장 정보 수정 처리
     @PostMapping("/deliveries/{deliveryId}/info")
-    public String updateDeliveryInfo(@PathVariable Long deliveryId,
+    public String updateDeliveryInfo(HttpServletRequest request,
+                                     @PathVariable Long deliveryId,
                                      @ModelAttribute DeliveryWaybillUpdateDto requestDto) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
 
-        deliveryClient.updateDeliveryInfo(deliveryId, requestDto);
+        deliveryClient.updateDeliveryInfo(token, deliveryId, requestDto);
 
         return "redirect:/admin/deliveries";
     }
 
     @GetMapping("/delivery-policies")
-    public String getDeliveries(@RequestParam(defaultValue = "0") int page,
+    public String getDeliveries(HttpServletRequest request,
+                                @RequestParam(defaultValue = "0") int page,
                                 @RequestParam(defaultValue = "10") int size,
                                 Model model) {
-        Page<DeliveryPolicyDto> deliveryPolicyPage = deliveryPolicyClient.getDeliveryPolicies(page, size);
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
+
+        Page<DeliveryPolicyDto> deliveryPolicyPage = deliveryPolicyClient.getDeliveryPolicies(token, page, size);
         log.info("배송 정책 조회: {}", deliveryPolicyPage.getTotalElements());
         model.addAttribute("deliveryPolicies", deliveryPolicyPage.getContent());
         model.addAttribute("currentPage", page);
@@ -313,9 +340,12 @@ public class AdminViewController {
     }
 
     @PostMapping("/delivery-policies")
-    public String createDeliveries(@ModelAttribute DeliveryPolicyDto dto) {
+    public String createDeliveries(HttpServletRequest request,
+                                   @ModelAttribute DeliveryPolicyDto dto) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
+
         log.info("배송 정책 요청 값: {}", dto);
-        deliveryPolicyClient.createDeliveryPolicy(dto);
+        deliveryPolicyClient.createDeliveryPolicy(token, dto);
         log.info("deliveryPolicyName = {}", dto.getDeliveryPolicyName());
         log.info("deliveryFee = {}", dto.getDeliveryFee());
         log.info("freeDeliveryThreshold = {}", dto.getFreeDeliveryThreshold());
@@ -331,9 +361,10 @@ public class AdminViewController {
     }
 
     @GetMapping("/delivery-policies/update/{id}")
-    public String updateForm(@PathVariable Long id, Model model) {
+    public String updateForm(HttpServletRequest request, @PathVariable Long id, Model model) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
 
-        DeliveryPolicyDto policy = deliveryPolicyClient.getDeliveryPolicy(id);
+        DeliveryPolicyDto policy = deliveryPolicyClient.getDeliveryPolicy(token, id);
 
         model.addAttribute("deliveryPolicyDto", policy);
         model.addAttribute("pageTitle", "배송 정책 수정");
@@ -342,10 +373,12 @@ public class AdminViewController {
 
     @PostMapping("/delivery-policies/{id}")
     public String updateDeliveryPolicy(
+            HttpServletRequest request,
             @PathVariable Long id,
             @ModelAttribute DeliveryPolicyDto dto) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
 
-        deliveryPolicyClient.updateDeliveryPolicy(id, dto);
+        deliveryPolicyClient.updateDeliveryPolicy(token, id, dto);
         return "redirect:/admin/delivery-policies";
     }
 

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/bookController/BookApiController.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/bookController/BookApiController.java
@@ -2,6 +2,8 @@ package com.nhnacademy.book2onandonfrontservice.controller.bookController;
 
 import com.nhnacademy.book2onandonfrontservice.client.BookClient;
 import com.nhnacademy.book2onandonfrontservice.dto.bookdto.BookLikeToggleResponse;
+import com.nhnacademy.book2onandonfrontservice.util.CookieUtils;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -20,15 +22,17 @@ public class BookApiController {
     private final BookClient bookClient;
 
     @PostMapping("/{bookId}/likes")
-    public ResponseEntity<?> toggleLike(@PathVariable Long bookId){
-        try{
-            BookLikeToggleResponse response = bookClient.toggleLike(bookId);
+    public ResponseEntity<?> toggleLike(HttpServletRequest request,
+                                        @PathVariable Long bookId) {
+        String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
+        try {
+            BookLikeToggleResponse response = bookClient.toggleLike(token, bookId);
             return ResponseEntity.ok(response);
-        }catch (Exception e){
+        } catch (Exception e) {
             String msg = e.getMessage();
             log.error("좋아요 요청 실패: {}", msg);
 
-            if(msg!= null && msg.contains("401")){
+            if (msg != null && msg.contains("401")) {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("로그인이 필요합니다.");
             }
 

--- a/src/main/resources/templates/admin/grades/list.html
+++ b/src/main/resources/templates/admin/grades/list.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>관리자 - 회원 등급 관리</title>
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+    <link rel="stylesheet" th:href="@{/css/admin.css}">
+    <style>
+        .grade-badge {
+            padding: 4px 8px;
+            border-radius: 6px;
+            color: white;
+            font-weight: 700;
+            font-size: 0.85rem;
+            background-color: #6c757d;
+        }
+
+        .grade-BASIC {
+            background-color: #6c757d;
+        }
+
+        .grade-ROYAL {
+            background-color: #17a2b8;
+        }
+
+        .grade-GOLD {
+            background-color: #ffc107;
+            color: #333;
+        }
+
+        .grade-PLATINUM {
+            background-color: #6f42c1;
+        }
+
+        /* 새로 추가될 등급용 스타일 (미리 정의) */
+        .grade-DIAMOND {
+            background-color: #0dcaf0;
+            color: #000;
+        }
+
+        .grade-VIP {
+            background-color: #dc3545;
+        }
+    </style>
+</head>
+<body>
+
+<th:block
+        th:replace="~{fragments/layout :: commonHeader(${user} ?: ${session.user}, ${cartCount}, null, null, false)}"></th:block>
+
+<div class="admin-container">
+    <th:block th:replace="~{fragments/admin :: adminSidebar('grades')}"></th:block>
+
+    <main class="admin-content">
+        <div class="admin-header">
+            <div>
+                <p class="eyebrow">회원 설정</p>
+                <h2>회원 등급 관리</h2>
+            </div>
+            <button class="btn-accent" onclick="openCreateModal()">+ 미등록 등급 활성화</button>
+        </div>
+
+        <div th:if="${param.error}"
+             style="background:#ffebee; color:#c62828; padding:10px; margin-bottom:10px; border-radius:4px;">
+            ❌ 이미 존재하는 등급이거나 잘못된 요청입니다.
+        </div>
+
+        <div class="table-card">
+            <table class="admin-table">
+                <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>등급명</th>
+                    <th>적립률</th>
+                    <th>기준 금액</th>
+                    <th>관리</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="grade : ${grades}">
+                    <td th:text="${grade.gradeId}">1</td>
+                    <td>
+                        <span class="grade-badge" th:classappend="|grade-${grade.gradeName}|"
+                              th:text="${grade.gradeName}">BASIC</span>
+                    </td>
+                    <td>
+                        <strong style="color: #2d5016;"
+                                th:text="${grade.pointAddRate != null ? #numbers.formatPercent(grade.pointAddRate, 1, 1) : '0%'}"></strong>
+                    </td>
+                    <td th:text="${#numbers.formatInteger(grade.pointCutline, 0, 'COMMA')} + '원'"></td>
+                    <td class="table-actions">
+                        <button class="btn-small" type="button"
+                                th:onclick="openUpdateModal([[${grade.gradeId}]], [[${grade.gradeName}]], [[${grade.pointAddRate}]], [[${grade.pointCutline}]])">
+                            수정
+                        </button>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <div class="admin-toolbar" style="margin-top: 20px;">
+            <p class="muted" style="font-size: 0.9rem;">
+                ℹ️ <strong>기준 금액</strong>: 최근 3개월간의 순수 주문 금액(배송비/포장비 제외) 합계입니다.<br>
+                ℹ️ 등급 산정은 매 분기(1, 4, 7, 10월) 1일 새벽에 자동으로 수행됩니다.<br>
+                ⚠️ <strong>주의:</strong> 새로운 등급을 추가하려면 먼저 개발팀을 통해 <strong>서버 코드(Enum)에 등급명이 반영</strong>되어야 합니다.<br>
+                코드가 배포된 후, 이 화면에서 '미등록 등급 활성화'를 통해 세부 정책(적립률, 기준금액)을 설정해 주세요.
+            </p>
+        </div>
+    </main>
+</div>
+
+<div id="gradeModal" class="modal-overlay">
+    <div class="modal-card">
+        <h3 id="modalTitle" style="margin-top: 0; margin-bottom: 1rem; color: #2d5016;">등급 설정</h3>
+
+        <form id="gradeForm" method="post">
+            <div class="form-field">
+                <label for="gradeName">등급명</label>
+                <input type="text" id="gradeName" name="gradeName" class="form-control" placeholder="예: DIAMOND"
+                       required>
+                <p class="helper-text" id="nameHelper" style="font-size:0.8rem; color:#888; margin-top:4px;">
+                    * 개발팀으로부터 먼저 <strong>등급명을 제공받은 후</strong> 입력해주세요.
+                </p>
+            </div>
+
+            <div class="form-grid">
+                <div class="form-field">
+                    <label for="pointAddRate">적립률 (소수점)</label>
+                    <input type="number" id="pointAddRate" name="pointAddRate" class="form-control" placeholder="0.05"
+                           step="0.001" min="0" max="1" required>
+                </div>
+                <div class="form-field">
+                    <label for="pointCutline">기준 금액 (원)</label>
+                    <input type="number" id="pointCutline" name="pointCutline" class="form-control" placeholder="500000"
+                           min="0" step="1000" required>
+                </div>
+            </div>
+
+            <div class="modal-actions">
+                <button type="button" class="btn-ghost" onclick="closeModal()">취소</button>
+                <button type="submit" class="btn-primary" id="submitBtn">저장</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<th:block th:replace="~{fragments/layout :: commonFooter}"></th:block>
+
+<script>
+    const modal = document.getElementById('gradeModal');
+    const form = document.getElementById('gradeForm');
+    const modalTitle = document.getElementById('modalTitle');
+    const submitBtn = document.getElementById('submitBtn');
+
+    const nameInput = document.getElementById('gradeName');
+    const nameHelper = document.getElementById('nameHelper');
+    const rateInput = document.getElementById('pointAddRate');
+    const cutlineInput = document.getElementById('pointCutline');
+
+    function closeModal() {
+        modal.classList.remove('show');
+    }
+
+    // [등록 모달] : 코드엔 있지만 DB엔 없는 등급 추가용
+    function openCreateModal() {
+        modalTitle.textContent = '미등록 등급 활성화';
+        submitBtn.textContent = '등록';
+        form.action = '/admin/grades'; // POST (생성)
+
+        nameInput.value = '';
+        nameInput.readOnly = false;
+        nameInput.style.backgroundColor = '#fff';
+        nameHelper.style.display = 'block';
+
+        rateInput.value = '';
+        cutlineInput.value = '';
+
+        modal.classList.add('show');
+    }
+
+    // [수정 모달] : 기존 등급 정책 변경
+    function openUpdateModal(id, name, rate, cutline) {
+        modalTitle.textContent = '등급 정책 수정';
+        submitBtn.textContent = '수정 완료';
+        form.action = `/admin/grades/${id}/update`; // POST -> Controller에서 처리
+
+        nameInput.value = name;
+        nameInput.readOnly = true;
+        nameInput.style.backgroundColor = '#f0f0f0';
+        nameHelper.style.display = 'none';
+
+        rateInput.value = rate;
+        cutlineInput.value = cutline;
+
+        modal.classList.add('show');
+    }
+
+    window.onclick = function (event) {
+        if (event.target === modal) closeModal();
+    }
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/fragments/admin.html
+++ b/src/main/resources/templates/fragments/admin.html
@@ -5,6 +5,7 @@
             <!-- TODO: 아이콘 변경하기 -->
             <a th:classappend="${activeMenu}=='dashboard' ? ' active'" th:href="@{/admin}">대시보드</a>
             <a th:classappend="${activeMenu}=='users' ? ' active'" th:href="@{/admin/users}">회원 관리</a>
+            <a th:classappend="${activeMenu}=='grades' ? ' active'" th:href="@{/admin/grades}">등급 관리</a>
             <a th:classappend="${activeMenu}=='books' ? ' active'" th:href="@{/admin/books/create}">도서 관리</a>
             <a th:classappend="${activeMenu}=='orders' ? ' active'" th:href="@{/admin/orders}">주문 관리</a>
             <a th:classappend="${activeMenu}=='deliveries' ? ' active'" th:href="@{/admin/deliveries}">배송 관리</a>


### PR DESCRIPTION
Bugfix/ api요청시 accesstoken을 보내도록 수정

## 🔀 PR 개요

변경된 내용이나 주요 작업 내용을 간략히 설명해 주세요.
- 등급관리 페이지 구현
- 관리자페이지 api 요청시 Authorization 토큰을 보내지 않아 권한검사가 제대로 안되는 문제를 해결

예시:

- 로그인 API 응답 포맷 수정
- 도서 상세 페이지 스타일링 개선

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.
- 등급관리 페이지 구현
 등급의 경우 등급명이 ENUM타입으로 되어있기 때문에 새 등급을 만들기 위해서는 개발팀으로부터 새 등급명을 db에 넣게 요청한 후 생성 가능합니다.
- 관리자페이지 api 요청시 Authorization 토큰을 보내지 않아 권한검사가 제대로 안되는 문제를 해결

- [x] 새로운 기능 추가 (✨ Feature)
- [x] 버그 수정 (🐞 BugFix)
- [ ] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

---

## 💡 변경 이유

왜 이 변경이 필요한지, 어떤 문제를 해결하려는 것인지 설명해 주세요.

---

## 🧩 관련 이슈

연결된 이슈 번호를 적어주세요.  
예시:

- Closes #12
- Fixes #45

---

## 🧪 테스트 방법

변경 내용을 확인할 수 있는 방법을 단계별로 설명해 주세요.  
코드 블록(```)으로 콘솔 로그나 테스트 코드 결과를 첨부해도 좋습니다.

예시:

```bash
# 로컬 서버 실행
npm run dev
# 또는
python manage.py runserver
