### PR TITLE
Feature/마이페이지 등급 표시 및 등급안내. 관리자페이지 권한미달시 팝업과함께 접속이 안되도록함

### DIFF
--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/UserGradeClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/UserGradeClient.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 public interface UserGradeClient {
     // 전체 등급 조회
     @GetMapping("/api/admin/grades")
-    List<UserGradeDto> getAllGrades(@RequestHeader("Authorization") String accessToken);
+    List<UserGradeDto> getAllGrades();
 
     // 등급 생성
     @PostMapping("/api/admin/grades")

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/adminController/AdminViewController.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/adminController/AdminViewController.java
@@ -185,13 +185,11 @@ public class AdminViewController {
 
     /// 도서 등록
     @PostMapping("/books/create")
-
-    public String createBook(HttpServletRequest request, @ModelAttribute(value = "book") BookSaveRequest req,
+    public String createBook(HttpServletRequest request, @ModelAttribute BookSaveRequest req,
                              @RequestParam(value = "images", required = false) List<MultipartFile> images) {
-        log.info("북서비스 등록 BookSaveRequest: {}", req.toString());
         String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
 
-        bookClient.createBook(token,req, images);
+        bookClient.createBook(token, req, images);
         return "redirect:/admin/books";
     }
 
@@ -242,7 +240,7 @@ public class AdminViewController {
     @GetMapping("/grades")
     public String gradeList(HttpServletRequest request, Model model) {
         String token = "Bearer " + CookieUtils.getCookieValue(request, "accessToken");
-        List<UserGradeDto> grades = userGradeClient.getAllGrades(token);
+        List<UserGradeDto> grades = userGradeClient.getAllGrades();
         model.addAttribute("grades", grades);
         return "admin/grades/list";
     }

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/userController/MyPageViewController.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/userController/MyPageViewController.java
@@ -5,12 +5,14 @@ import com.nhnacademy.book2onandonfrontservice.client.BookClient;
 import com.nhnacademy.book2onandonfrontservice.client.MemberCouponClient;
 import com.nhnacademy.book2onandonfrontservice.client.PointUserClient;
 import com.nhnacademy.book2onandonfrontservice.client.UserClient;
+import com.nhnacademy.book2onandonfrontservice.client.UserGradeClient;
 import com.nhnacademy.book2onandonfrontservice.dto.bookdto.MyLikedBookResponseDto;
 import com.nhnacademy.book2onandonfrontservice.dto.memberCouponDto.MemberCouponDto;
 import com.nhnacademy.book2onandonfrontservice.dto.memberCouponDto.MemberCouponStatus;
 import com.nhnacademy.book2onandonfrontservice.dto.pointDto.pointHistory.CurrentPointResponseDto;
 import com.nhnacademy.book2onandonfrontservice.dto.pointDto.pointHistory.PointHistoryResponseDto;
 import com.nhnacademy.book2onandonfrontservice.dto.userDto.RestPage;
+import com.nhnacademy.book2onandonfrontservice.dto.userDto.UserGradeDto;
 import com.nhnacademy.book2onandonfrontservice.dto.userDto.request.PasswordChangeRequest;
 import com.nhnacademy.book2onandonfrontservice.dto.userDto.request.UserAddressCreateRequest;
 import com.nhnacademy.book2onandonfrontservice.dto.userDto.request.UserAddressUpdateRequest;
@@ -55,6 +57,7 @@ public class MyPageViewController {
     private final BookClient bookClient;
     private final MemberCouponClient memberCouponClient;
     private final PointUserClient pointUserClient;
+    private final UserGradeClient userGradeClient;
 
     //마이페이지
     @GetMapping
@@ -290,6 +293,16 @@ public class MyPageViewController {
                     .build();
 
             model.addAttribute("userUpdateRequest", updateRequest);
+            model.addAttribute("gradeName", user.getGradeName());
+
+            try {
+                List<UserGradeDto> allGrades = userGradeClient.getAllGrades();
+                allGrades.sort(Comparator.comparingInt(UserGradeDto::getPointCutline));
+                model.addAttribute("allGrades", allGrades);
+            } catch (Exception e) {
+                log.warn("등급 목록 조회 실패", e);
+                model.addAttribute("allGrades", List.of());
+            }
 
             return "user/mypage/edit";
         } catch (Exception e) {

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/interceptor/AdminInterceptor.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/interceptor/AdminInterceptor.java
@@ -4,6 +4,7 @@ import com.nhnacademy.book2onandonfrontservice.util.CookieUtils;
 import com.nhnacademy.book2onandonfrontservice.util.JwtUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.PrintWriter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
@@ -11,23 +12,90 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Slf4j
 @Component
 public class AdminInterceptor implements HandlerInterceptor {
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
             throws Exception {
 
+        // 토큰 확인
         String token = CookieUtils.getCookieValue(request, "accessToken");
-
         if (token == null) {
             response.sendRedirect("/login");
             return false;
         }
 
+        // 역할 및 요청 URL 추출
         String role = JwtUtils.getRole(token);
+        String requestURI = request.getRequestURI();
+
+        // 기본 관리자 권한 체크
         if (role == null || !role.contains("ADMIN")) {
-            log.warn("관리자 페이지 접근 거부: IP={}, Role={}", request.getRemoteAddr(), role);
-            response.sendRedirect("/");
+            sendAlertAndRedirect(response, "관리자 페이지 접근 권한이 없습니다.", "/");
             return false;
         }
+
+        // SUPER_ADMIN은 모든 페이지 프리패스
+        if ("ROLE_SUPER_ADMIN".equals(role)) {
+            return true;
+        }
+
+        // 세부 권한별 접근 제어 (권한 없으면 메세지 띄우고 이전페이지로)
+        if (!hasPermission(requestURI, role)) {
+            log.warn("권한 부족 접근 시도: URI={}, Role={}", requestURI, role);
+            sendAlertAndBack(response, "해당 메뉴에 대한 접근 권한이 없습니다.");
+            return false;
+        }
+
         return true;
+    }
+
+    /**
+     * URL별 필요 권한 체크 로직
+     */
+    private boolean hasPermission(String uri, String role) {
+        // [회원 관리자] : 회원, 등급, 포인트 내역
+        if (uri.startsWith("/admin/users") || uri.startsWith("/admin/grades") || uri.startsWith("/admin/points")) {
+            return "ROLE_MEMBER_ADMIN".equals(role);
+        }
+
+        // [도서 관리자] : 도서 관리
+        if (uri.startsWith("/admin/books")) {
+            return "ROLE_BOOK_ADMIN".equals(role);
+        }
+
+        // [쿠폰 관리자] : 쿠폰, 쿠폰 정책, 포인트 정책
+        if (uri.startsWith("/admin/coupons") || uri.startsWith("/admin/policies") || uri.startsWith(
+                "/admin/point-policies")) {
+            return "ROLE_COUPON_ADMIN".equals(role);
+        }
+
+        // [주문 관리자] : 주문, 배송, 배송 정책
+        if (uri.startsWith("/admin/orders") || uri.startsWith("/admin/deliveries") || uri.startsWith(
+                "/admin/delivery-policies")) {
+            return "ROLE_ORDER_ADMIN".equals(role);
+        }
+
+        // 그 외 페이지(대시보드 /admin 등)는 모든 관리자가 접근 가능
+        return true;
+    }
+
+    /**
+     * 알림창을 띄우고 이전 페이지로 이동시키는 메서드
+     */
+    private void sendAlertAndBack(HttpServletResponse response, String msg) throws Exception {
+        response.setContentType("text/html; charset=UTF-8");
+        PrintWriter out = response.getWriter();
+        out.println("<script>alert('" + msg + "'); history.back();</script>");
+        out.flush();
+    }
+
+    /**
+     * 알림창을 띄우고 특정 URL로 이동시키는 메서드
+     */
+    private void sendAlertAndRedirect(HttpServletResponse response, String msg, String url) throws Exception {
+        response.setContentType("text/html; charset=UTF-8");
+        PrintWriter out = response.getWriter();
+        out.println("<script>alert('" + msg + "'); location.href='" + url + "';</script>");
+        out.flush();
     }
 }

--- a/src/main/resources/templates/user/mypage/edit.html
+++ b/src/main/resources/templates/user/mypage/edit.html
@@ -11,11 +11,165 @@
 
 <body>
 <div th:fragment="content">
+    <style>
+        /* 등급 안내 메시지 영역 */
+        .grade-info-box {
+            background-color: #f8fbf8;
+            border: 1px solid #e0e7e2;
+            border-radius: 12px;
+            padding: 15px 20px;
+            margin-bottom: 20px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            color: #333;
+        }
+
+        .grade-text strong {
+            color: #2d5016;
+            font-size: 1.1rem;
+        }
+
+        .btn-grade-guide {
+            background-color: #fff;
+            border: 1px solid #2d5016;
+            color: #2d5016;
+            padding: 6px 12px;
+            border-radius: 6px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+        }
+
+        .btn-grade-guide:hover {
+            background-color: #2d5016;
+            color: #fff;
+        }
+
+        /* 모달 스타일 */
+        .modal-overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.5);
+            z-index: 2000;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .modal-card {
+            background: white;
+            width: 90%;
+            max-width: 500px;
+            border-radius: 16px;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+            overflow: hidden;
+            animation: slideUp 0.3s ease-out;
+        }
+
+        @keyframes slideUp {
+            from {
+                transform: translateY(20px);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0);
+                opacity: 1;
+            }
+        }
+
+        .modal-header {
+            padding: 15px 20px;
+            background: #2d5016;
+            color: white;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .modal-header h3 {
+            margin: 0;
+            font-size: 1.1rem;
+            color: white;
+        }
+
+        .close-btn {
+            background: none;
+            border: none;
+            color: white;
+            font-size: 1.5rem;
+            cursor: pointer;
+        }
+
+        .modal-body {
+            padding: 20px;
+        }
+
+        /* 등급 리스트 스타일 */
+        .grade-list-item {
+            display: flex;
+            align-items: center;
+            padding: 12px 0;
+            border-bottom: 1px solid #eee;
+        }
+
+        .grade-list-item:last-child {
+            border-bottom: none;
+        }
+
+        .grade-badge {
+            min-width: 80px;
+            text-align: center;
+            padding: 4px 8px;
+            border-radius: 6px;
+            font-weight: bold;
+            font-size: 0.8rem;
+            color: white;
+            margin-right: 15px;
+        }
+
+        /* 등급별 색상 (필요시 classappend로 사용) */
+        .bg-BASIC {
+            background-color: #6c757d;
+        }
+
+        .bg-ROYAL {
+            background-color: #17a2b8;
+        }
+
+        .bg-GOLD {
+            background-color: #ffc107;
+            color: #333 !important;
+        }
+
+        .bg-PLATINUM {
+            background-color: #6f42c1;
+        }
+
+        .grade-desc {
+            font-size: 0.9rem;
+            color: #555;
+        }
+
+        .grade-desc strong {
+            color: #2d5016;
+        }
+    </style>
 
     <div class="address-form-container no-card">
         <h2>정보 관리</h2>
 
         <div class="error-box" th:if="${error}" th:text="${error}"></div>
+        <div class="grade-info-box">
+            <div class="grade-text">
+                회원님의 현재 등급은 <strong th:text="${gradeName}">BASIC</strong> 입니다.
+            </div>
+            <button type="button" class="btn-grade-guide" onclick="openGradeModal()">등급안내</button>
+        </div>
 
         <form method="post" onsubmit="return validateForm()" th:action="@{/users/me/edit}"
               th:object="${userUpdateRequest}">
@@ -66,8 +220,57 @@
 
         </form>
     </div>
+    <div id="gradeModal" class="modal-overlay">
+        <div class="modal-card">
+            <div class="modal-header">
+                <h3>회원 등급 안내</h3>
+                <button class="close-btn" onclick="closeGradeModal()">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div th:if="${#lists.isEmpty(allGrades)}">
+                    <p style="text-align:center; color:#999;">등급 정책 정보를 불러올 수 없습니다.</p>
+                </div>
+                <div th:unless="${#lists.isEmpty(allGrades)}">
+                    <div class="grade-list-item" th:each="grade : ${allGrades}">
+                        <span class="grade-badge"
+                              th:classappend="|bg-${grade.gradeName}|"
+                              th:text="${grade.gradeName}">BASIC</span>
+
+                        <div class="grade-desc">
+                            <div>포인트 적립률: <strong
+                                    th:text="${#numbers.formatInteger(grade.pointAddRate * 100, 0, 'COMMA')} + '%'">1%</strong>
+                            </div>
+                            <div style="font-size:0.85rem; color:#888; margin-top:2px;">
+                                (최근 3개월 순수 주문 <span th:text="${#numbers.formatInteger(grade.pointCutline, 0, 'COMMA')}">0</span>원
+                                이상)
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div style="margin-top: 20px; font-size: 0.85rem; color: #888; background: #f9f9f9; padding: 10px; border-radius: 8px;">
+                    💡 등급은 매 분기(1, 4, 7, 10월) 1일에 최근 3개월 실적을 기준으로 반영됩니다.
+                </div>
+            </div>
+        </div>
+    </div>
 
     <script>
+        // [4. 모달 제어 스크립트]
+        function openGradeModal() {
+            document.getElementById('gradeModal').style.display = 'flex';
+        }
+
+        function closeGradeModal() {
+            document.getElementById('gradeModal').style.display = 'none';
+        }
+
+        // 모달 배경 클릭 시 닫기
+        window.addEventListener('click', function (event) {
+            const modal = document.getElementById('gradeModal');
+            if (event.target === modal) {
+                closeGradeModal();
+            }
+        });
         const originalEmail = document.getElementById('originalEmail').value;
         let isEmailVerified = true;
 

--- a/src/main/resources/templates/user/mypage/index.html
+++ b/src/main/resources/templates/user/mypage/index.html
@@ -11,6 +11,33 @@
 
 <body>
 <div th:fragment="content">
+    <style>
+        .badge {
+            padding: 5px 10px;
+            border-radius: 4px;
+            font-size: 0.8rem;
+            color: white; /* 기본 글자색 흰색 */
+            font-weight: bold;
+        }
+
+        /* 등급별 배경색 (작성해주신 코드) */
+        .bg-BASIC {
+            background-color: #6c757d;
+        }
+
+        .bg-ROYAL {
+            background-color: #17a2b8;
+        }
+
+        .bg-GOLD {
+            background-color: #ffc107;
+            color: #333 !important; /* 골드는 글씨가 어두워야 잘 보임 */
+        }
+
+        .bg-PLATINUM {
+            background-color: #6f42c1;
+        }
+    </style>
     <div class="dashboard-header">
         <h2>대시보드</h2>
         <p class="muted">내 활동을 한 눈에 확인하세요.</p>
@@ -28,6 +55,13 @@
             <!--            <p class="subtext" th:text="${user.email}">email@example.com</p>-->
             <p class="subtext address-line"
                th:text="${defaultAddress != null ? defaultAddress : '기본 주소를 등록해 주세요.'}">주소 정보</p>
+            <div style="margin-top: auto; padding-top: 10px;">
+                <span class="badge"
+                      th:text="${user.gradeName} + ' 등급'"
+                      th:classappend="|bg-${user.gradeName}|">
+                    BASIC 등급
+                </span>
+            </div>
         </a>
 
         <a class="dashboard-card link-card coupon-card" th:href="@{/users/me/coupons}">


### PR DESCRIPTION
## 🔀 PR 개요

변경된 내용이나 주요 작업 내용을 간략히 설명해 주세요.
- 기존 마이페이지에서 회원 등급이 표시가 안되었는데 대시보드에 등급표시와 정보관리에서 등급안내를 해주도록함.
- 관리자페이지에서 부서권한이 없을시 메세지와 함께 접속이 안되도록함.

예시:

- 로그인 API 응답 포맷 수정
- 도서 상세 페이지 스타일링 개선

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.
- 마이페이지에서 전체 등급안내를 위해 getAllGrades에 있던 권한 제한을 없앰.
- 마이페이지에서 등급안내는 팝업으로 띄움
- 마이페이지에서 회원 등급이 표시되도록 마이페이지 뷰 컨트롤러를 수정
- 관리자페이지에서 부서별 관리자페이지 주소로 끊어서 권한이 없을시 못들어가도록함..

- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [ ] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

---

## 💡 변경 이유

왜 이 변경이 필요한지, 어떤 문제를 해결하려는 것인지 설명해 주세요.

---

## 🧩 관련 이슈

연결된 이슈 번호를 적어주세요.  


---

## 🧪 테스트 방법

변경 내용을 확인할 수 있는 방법을 단계별로 설명해 주세요.  
코드 블록(```)으로 콘솔 로그나 테스트 코드 결과를 첨부해도 좋습니다.

예시:

```bash
# 로컬 서버 실행
npm run dev
# 또는
python manage.py runserver
