### PR TITLE
[Feat] 주문·반품·포장지 서비스 연동을 위한 Feign Client 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,8 @@ build/
 
 ### VS Code ###
 .vscode/
+
+
 .env
 application-local.properties
+.DS_Store

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/DeliveryClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/DeliveryClient.java
@@ -2,7 +2,7 @@ package com.nhnacademy.book2onandonfrontservice.client;
 
 import com.nhnacademy.book2onandonfrontservice.dto.deliveryDto.DeliveryDto;
 import com.nhnacademy.book2onandonfrontservice.dto.deliveryDto.DeliveryWaybillUpdateDto;
-import com.nhnacademy.book2onandonfrontservice.dto.orderDto.OrderStatus;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.status.OrderStatus;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/OrderUserClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/OrderUserClient.java
@@ -1,0 +1,66 @@
+package com.nhnacademy.book2onandonfrontservice.client;
+
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.request.OrderCreateRequestDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.OrderCancelResponseDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.OrderCreateResponseDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.OrderDetailResponseDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.OrderPrepareResponseDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.OrderSimpleDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "gateway-service", contextId = "OrderUserClient", url = "${gateway.base-url}")
+public interface OrderUserClient {
+
+    /**
+     * 장바구니 혹은 바로구매시 준비할 데이터 (책 정보, 회원 배송지 정보)
+     * POST /api/orders/prepare
+     */
+    @PostMapping("/api/orders/prepare")
+    OrderPrepareResponseDto getOrderPrepare(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                                            @RequestBody OrderPrepareResponseDto responseDto);
+
+    /**
+     * 주문 생성(결제 직전 사전 주문데이터 생성)
+     * POST /api/orders
+     */
+    @PostMapping("/api/orders")
+    OrderCreateResponseDto createPreOrder(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                                          @RequestBody OrderCreateRequestDto requestDto);
+
+    /**
+     * 내 주문 목록 조회
+     * GET /api/orders/my-order
+     * Pageable은 쿼리 파라미터 (?page=0&size=20)로 변환되어 전달
+     */
+    @GetMapping("/api/orders/my-order")
+    Page<OrderSimpleDto> getOrderList(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                                      Pageable pageable);
+
+    /**
+     * 주문 상세 조회
+     * GET /api/orders/{orderNumber}
+     */
+
+    @GetMapping("/api/orders/{orderNumber}")
+    OrderDetailResponseDto getOrderDetail(
+            @RequestHeader(value = "Authorization", required = false) String accessToken,
+            @PathVariable("orderNumber") String orderNumber
+    );
+
+    /**
+     * 결제 후 바로 주문 취소하는 경우
+     * 백엔드가 204 no Content를 보내더라도 Dto를 리턴 타입으로 두면 null 들어옴 만약 백엔드에서 200을
+     */
+    @PatchMapping("/api/orders/{orderNumber}/cancel")
+    OrderCancelResponseDto cancelOrder(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                       @PathVariable("orderNumber") String orderNumber);
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/PaymentClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/PaymentClient.java
@@ -1,0 +1,17 @@
+package com.nhnacademy.book2onandonfrontservice.client;
+
+import com.nhnacademy.book2onandonfrontservice.dto.paymentDto.request.CommonConfirmRequest;
+import com.nhnacademy.book2onandonfrontservice.dto.paymentDto.response.PaymentResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "gateway-service", contextId = "paymentClient", url = "${gateway.base-url}")
+public interface PaymentClient {
+    @PostMapping("/payment/{provider}/confirm")
+    PaymentResponse confirmPayment(@RequestHeader("Authorization")String accessToken,
+                                   @PathVariable("provider")String provider,
+                                   @RequestBody CommonConfirmRequest req);
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/RefundAdminClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/RefundAdminClient.java
@@ -1,0 +1,43 @@
+package com.nhnacademy.book2onandonfrontservice.client;
+
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.request.RefundStatusUpdateRequestDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.RefundResponseDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.RefundSearchCondition;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "gateway-service", contextId = "RefundAdminClient", url = "${gateway.base-url}")
+public interface RefundAdminClient {
+    /**
+     * 관리자 반품 목록 조회(검색)
+     * @SpringQueryMap: 객체의 필드를 쿼리 파라미터로 펼쳐서 보냄
+     */
+    @GetMapping("/api/admin/refunds")
+    Page<RefundResponseDto> getRefundList(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                          @SpringQueryMap RefundSearchCondition condition,
+                                          Pageable pageable);
+
+    /**
+     * 관리자 반품 상세조회
+     * GET /api/admin/refunds/{refundId}
+     */
+    @GetMapping("/api/admin/refunds/{refundId}")
+    RefundResponseDto findRefundDetails(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                        @PathVariable Long refundId);
+
+    /**
+     * 관리자 반품 상태변경
+     * PatchMapping /api/admin/refunds/{refundId}
+     */
+    @PatchMapping("/api/admin/refunds/{refundId}")
+    RefundResponseDto updateRefundStatus(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                         @PathVariable Long refundId,
+                                         @RequestBody RefundStatusUpdateRequestDto requestDto);
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/RefundGuestClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/RefundGuestClient.java
@@ -1,0 +1,50 @@
+package com.nhnacademy.book2onandonfrontservice.client;
+
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.request.RefundGuestRequestDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.RefundAvailableItemResponseDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.RefundResponseDto;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "gateway-service", contextId = "RefundGuestClient", url = "${gateway.base-url}")
+public interface RefundGuestClient {
+
+    /**
+     * 비회원 반품 신청 폼 (반품 가능 목록 조회)
+     */
+    @GetMapping("/api/guest/orders/{orderId}/refunds/form")
+    List<RefundAvailableItemResponseDto> getRefundFormForGuest(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                                               @PathVariable("orderId") Long orderId);
+
+    /**
+     * 비회원 반품 신청
+     */
+    @PostMapping("/api/guest/orders/{orderId}/refunds")
+    RefundResponseDto createRefundForGuest(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                           @PathVariable Long orderId,
+                                           @RequestBody RefundGuestRequestDto requestDto);
+    /**
+     * 비회원 반품 상세 조회
+     */
+    @GetMapping("/api/guest/orders/{orderId}/refunds/{refundId}")
+    RefundResponseDto getRefundDetailsForGuest(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                               @PathVariable("orderId")Long orderId,
+                                               @PathVariable("refundId")Long refundId);
+
+    /**
+     * 비회원 반품 신청 취소
+     */
+    @PostMapping("/api/guest/orders/{orderId}/refunds/{refundId}")
+    RefundResponseDto cancelRefundForGuest(
+            @RequestHeader(value = "Authorization", required = false) String accessToken,
+            @PathVariable("orderId") Long orderId,
+            @PathVariable("refundId") Long refundId,
+            @RequestParam("guestPassword") String guestPassword
+    );
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/RefundUserClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/RefundUserClient.java
@@ -1,0 +1,59 @@
+package com.nhnacademy.book2onandonfrontservice.client;
+
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.RefundAvailableItemResponseDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.RefundResponseDto;
+import java.util.List;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "gateway-service", contextId = "RefundUserClient", url = "${gateway.base-url}")
+public interface RefundUserClient {
+
+    /**
+     * 회원 반품 신청 폼 : 반품 가능 품목 조회
+     */
+    @GetMapping("/api/orders/{orderId}/refunds/form")
+    List<RefundAvailableItemResponseDto> getRefundForm(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                                       @PathVariable("orderId") Long orderId);
+
+    /**
+     * 회원 반품 신청
+     */
+    @PostMapping("/api/orders/{orderId}/refunds")
+    RefundResponseDto createRefund(
+            @RequestHeader(value = "Authorization", required = false) String accessToken,
+            @PathVariable("orderId") String orderId,
+            @RequestBody RefundResponseDto requestDto
+    );
+
+    /**
+     * 회원 반품 상세 조회
+     */
+    @GetMapping("/api/orders/{orderId}/refunds/{refundId}")
+    RefundResponseDto getRefundDetails(
+            @RequestHeader(value = "Authorization", required = false) String accessToken,
+            @PathVariable("orderId") Long orderId,
+            @PathVariable("refundId") Long refundId
+    );
+
+    /**
+     * 회원 반품 신청 취소
+     */
+    @PostMapping("/api/orders/{orderId}/refunds/{refundId}/cancel")
+    RefundResponseDto cancelRefund(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                   @PathVariable("orderId")Long orderId,
+                                   @PathVariable("refundId")Long refundId);
+
+    /**
+     * 회원 전체 반품 목록 조회
+     */
+    @GetMapping("/orders/refunds/my-list")
+    Page<RefundResponseDto> getMyRefunds(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                         Pageable pageable);
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/WrappingPaperAdminClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/WrappingPaperAdminClient.java
@@ -1,0 +1,56 @@
+package com.nhnacademy.book2onandonfrontservice.client;
+
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.request.WrappingPaperRequestDto;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.WrappingPaperResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "gateway-service", contextId = "WrappingPaperAdminClient", url = "${gateway.base-url}")
+public interface WrappingPaperAdminClient {
+
+    /**
+     * 포장지 등록
+     */
+    @PostMapping("/api/admin/wrappapers")
+    WrappingPaperResponseDto createWrappingPaper(@RequestHeader(value = "Authorization", required = false) String accessToken,
+            @RequestBody WrappingPaperRequestDto requestDto);
+
+    /**
+     * 포장지 전체 목록 조회
+     */
+    @GetMapping("/api/admin/wrappapers")
+    Page<WrappingPaperResponseDto> getAllWrappingPapers(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                                        Pageable pageable);
+
+    /**
+     * 포장지 단건 조회
+     */
+    @GetMapping("/api/admin/wrappapers/{wrappingPaperId}")
+    WrappingPaperResponseDto getWrappingPaper(
+            @RequestHeader(value = "Authorization", required = false) String accessToken,
+            @PathVariable("wrappingPaperId") Long wrappingPaperId
+    );
+
+    /**
+     * 포장지 수정
+     */
+    @PutMapping("/api/admin/wrappapers/{wrappingPaperId}")
+    WrappingPaperResponseDto updateWrappingPaper(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                                                 @PathVariable("wrappingPaperId")Long wrappingPaperId);
+
+    /**
+     * 포장지 삭제
+     */
+    @DeleteMapping("/api/admin/wrappapers/{wrappingPaperId}")
+    void deleteWrappingPaper(@RequestHeader(value = "Authorization", required = false) String accessToken,
+                             @PathVariable("wrappingPaperId")Long wrappingPaperId);
+
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/client/WrappingPaperClient.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/client/WrappingPaperClient.java
@@ -1,0 +1,21 @@
+package com.nhnacademy.book2onandonfrontservice.client;
+
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.response.WrappingPaperSimpleResponseDto;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "gateway-service", contextId = "WrappingPaperClient", url = "${gateway.base-url}")
+public interface WrappingPaperClient {
+    /**
+     * 사용자 포장지 목록 조회
+     * 주문서 작성 화면에서 사용됨
+     */
+    @GetMapping("/api/wrappapers")
+    Page<WrappingPaperSimpleResponseDto> getWrappingPaperList(
+            @RequestHeader(value = "Authorization", required = false)String accessToken,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/adminController/AdminViewController.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/controller/adminController/AdminViewController.java
@@ -8,14 +8,13 @@ import com.nhnacademy.book2onandonfrontservice.client.DeliveryPolicyClient;
 import com.nhnacademy.book2onandonfrontservice.client.PointAdminClient;
 import com.nhnacademy.book2onandonfrontservice.client.UserClient;
 import com.nhnacademy.book2onandonfrontservice.client.UserGradeClient;
-import com.nhnacademy.book2onandonfrontservice.dto.bookdto.BookSearchCondition;
 import com.nhnacademy.book2onandonfrontservice.dto.couponDto.CouponDto;
 import com.nhnacademy.book2onandonfrontservice.dto.couponDto.CouponUpdateDto;
 import com.nhnacademy.book2onandonfrontservice.dto.deliveryDto.DeliveryCompany;
 import com.nhnacademy.book2onandonfrontservice.dto.deliveryDto.DeliveryDto;
 import com.nhnacademy.book2onandonfrontservice.dto.deliveryDto.DeliveryPolicyDto;
 import com.nhnacademy.book2onandonfrontservice.dto.deliveryDto.DeliveryWaybillUpdateDto;
-import com.nhnacademy.book2onandonfrontservice.dto.orderDto.OrderStatus;
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.status.OrderStatus;
 import com.nhnacademy.book2onandonfrontservice.dto.pointDto.pointHistory.CurrentPointResponseDto;
 import com.nhnacademy.book2onandonfrontservice.dto.pointDto.pointHistory.PointHistoryAdminAdjustRequestDto;
 import com.nhnacademy.book2onandonfrontservice.dto.pointDto.pointHistory.PointHistoryResponseDto;
@@ -31,7 +30,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -42,7 +40,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Slf4j
 @Controller

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/DeliveryAddressRequestDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/DeliveryAddressRequestDto.java
@@ -1,0 +1,25 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+/**
+ * 주문 시 고객이 입력한 배송지 상세 정보를 담는 DTO.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeliveryAddressRequestDto {
+    @NotNull(message = "주소를 입력해주세요")
+    private String deliveryAddress;
+    private String deliveryAddressDetail;
+    private String deliveryMessage;
+    @NotNull(message = "수령인을 입력해주세요")
+    private String recipient;
+    @NotNull(message = "수령인 전화번호를 입력해주세요")
+    private String recipientPhoneNumber; // 추가된 필드 (필수 가정)
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/OrderCreateRequestDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/OrderCreateRequestDto.java
@@ -1,0 +1,24 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderCreateRequestDto {
+    private List<OrderItemRequestDto> orderItems;
+    private DeliveryAddressRequestDto deliveryAddress;
+    @NotNull(message = "배송방법을 선택해주세요")
+    private Long deliveryPolicyId; // 배송 방법 아이디
+    @NotNull(message = "원하는 배송날짜를 선택해주세요")
+    private LocalDate wantDeliveryDate;
+    private Long memberCouponId; // 하나의 주문에 하나의 쿠폰만 사용
+    private Integer point;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/OrderItemRequestDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/OrderItemRequestDto.java
@@ -1,0 +1,20 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+/**
+ * 개별 상품 주문 정보를 담는 DTO. OrderCreateRequestDto와 GuestOrderCreateDto에 사용
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderItemRequestDto {
+    private Long bookId;
+    private int quantity;   // or
+    private boolean isWrapped;// der_item_quantity
+    private Long wrappingPaperId;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/RefundGuestRequestDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/RefundGuestRequestDto.java
@@ -1,0 +1,33 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefundGuestRequestDto {
+
+    private Long orderId;
+
+    private List<RefundItemRequestDto> refundItems; // orderItemId, refundQuantity
+
+    @NotBlank
+    private String refundReason;
+
+    private String refundReasonDetail;
+
+    @NotBlank(message = "주문 비밀번호를 입력해주세요.")
+    private String guestPassword;
+
+    @NotBlank(message = "주문자 이름을 입력해주세요.")
+    private String guestName;
+
+    @NotBlank(message = "주문자 전화번호를 입력해주세요.")
+    private String guestPhoneNumber;
+
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/RefundItemRequestDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/RefundItemRequestDto.java
@@ -1,0 +1,24 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 반품할 개별 주문 항목 정보
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefundItemRequestDto {
+
+    @NotNull
+    private Long orderItemId; // 원 주문 항목 (OrderItem) ID
+
+    @Min(1)
+    private int refundQuantity; // 반품 수량
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/RefundStatusUpdateRequestDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/RefundStatusUpdateRequestDto.java
@@ -1,0 +1,14 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefundStatusUpdateRequestDto {
+    private int statusCode;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/WrappingPaperRequestDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/request/WrappingPaperRequestDto.java
@@ -1,0 +1,16 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WrappingPaperRequestDto {
+    private String wrappingPaperName;
+    private int wrappingPaperPrice;
+    private String wrappingPaperPath;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/BookOrderResponse.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/BookOrderResponse.java
@@ -1,0 +1,19 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// BookOrderResponse DTO (Book Service로부터 받을 응답)
+@Getter
+@NoArgsConstructor
+public class BookOrderResponse {
+    private Long bookId;
+    private String title;
+    private Long priceStandard;
+    private Long priceSales;
+    private String imageUrl;
+    private boolean isPackable;
+    private Integer stockCount;
+    private String stockStatus;
+    private Long categoryId;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/DeliveryAddressResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/DeliveryAddressResponseDto.java
@@ -1,0 +1,8 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+public record DeliveryAddressResponseDto(String deliveryAddress,
+                                         String deliveryAddressDetail,
+                                         String deliveryMessage,
+                                         String recipient,
+                                         String recipientPhoneNumber) {
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/MemberCouponResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/MemberCouponResponseDto.java
@@ -1,0 +1,16 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import java.time.LocalDateTime;
+
+public class MemberCouponResponseDto {
+    private Long memberCouponId;
+    private String couponName;
+    private Integer minPrice;   // 최소 주문 금액
+    private Integer maxPrice;   // 최대 할인 금액
+    private Integer discountValue;
+    private String discountType;       // Enum 대신 String으로 받아도 무방
+    private String memberCouponStatus; // Enum 대신 String으로 받아도 무방
+    private LocalDateTime memberCouponEndDate;
+    private LocalDateTime memberCouponUseDate;
+    private String discountDescription;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderCancelResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderCancelResponseDto.java
@@ -1,0 +1,9 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import com.nhnacademy.book2onandonfrontservice.dto.paymentDto.response.PaymentCancelResponse;
+import java.util.List;
+
+public record OrderCancelResponseDto(String orderNumber,
+                                     String orderStatus,
+                                     List<PaymentCancelResponse> paymentCancelResponseList) {
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderCreateResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderCreateResponseDto.java
@@ -1,0 +1,29 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderCreateResponseDto {
+    private Long orderId;
+    private String orderNumber;
+    private String orderTitle;
+    private int totalItemAmount;
+    private int deliveryFee;
+    private int wrappingFee;
+    private int couponDiscount;
+    private int pointDiscount;
+    private int totalDiscountAmount;
+    private int totalAmount;
+    private LocalDate wantDeliveryDate;
+
+    private List<OrderItemCreateResponseDto> orderItemCreateResponseDtoList;
+    private DeliveryAddressResponseDto deliveryAddressResponseDto;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderDetailResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderDetailResponseDto.java
@@ -1,0 +1,45 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.status.OrderStatus;
+import com.nhnacademy.book2onandonfrontservice.dto.paymentDto.response.PaymentResponse;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderDetailResponseDto {
+    // 1. 주문 기본 정보
+    private Long orderId;
+    private String orderNumber;
+    private OrderStatus orderStatus;
+    private LocalDateTime orderDatetime;
+
+    // 2. 금액 상세 정보 (Order 엔티티)
+    private int totalAmount;
+    private int totalDiscountAmount;
+    private int totalItemAmount;
+    private int deliveryFee;
+    private int wrappingFee;
+    private int couponDiscount;
+    private int pointDiscount;
+
+    // 배송 희망 날짜
+    private LocalDate wantDeliveryDate;
+
+    // 3. 주문 상품 목록 (상세 조회용)
+    private List<OrderItemResponseDto> orderItems;
+
+    // 4. 배송지 정보
+    private DeliveryAddressResponseDto deliveryAddress;
+
+    // 5. 결제 정보
+    private PaymentResponse paymentResponse;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderItemCreateResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderItemCreateResponseDto.java
@@ -1,0 +1,13 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.status.OrderItemStatus;
+
+public record OrderItemCreateResponseDto(Long orderItemId,
+                                         Long bookId,
+                                         Integer orderItemQuantity,
+                                         Integer unitPrice,
+                                         boolean isWrapped,
+                                         OrderItemStatus orderItemStatus,
+                                         Long wrappingPaperId) {
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderItemResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderItemResponseDto.java
@@ -1,0 +1,22 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OrderItemResponseDto {
+    private Long orderItemId;
+    private Long bookId;
+    private String bookTitle;
+    private String bookImageUrl;
+    private Integer orderItemQuantity;
+    private Integer unitPrice;
+    private boolean isWrapped;
+    private String orderItemStatus;
+    private Long wrappingPaperId;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderPrepareResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderPrepareResponseDto.java
@@ -1,0 +1,18 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+
+import com.nhnacademy.book2onandonfrontservice.dto.pointDto.pointHistory.CurrentPointResponseDto;
+import java.util.List;
+
+public record
+OrderPrepareResponseDto(
+        // 책 아이템 조회
+        List<BookOrderResponse> orderItems,
+        // 유저 배송지 조회
+        List<UserAddressResponseDto> addresses,
+        // 사용할 수 있는 쿠폰 조회
+        List<MemberCouponResponseDto> coupons,
+        // 유저 포인트 조회
+        CurrentPointResponseDto currentPoint
+) {
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderSimpleDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/OrderSimpleDto.java
@@ -1,0 +1,26 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import com.nhnacademy.book2onandonfrontservice.dto.orderDto.status.OrderStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 주문 목록 페이지에서 핵심 요약 정보만 제공
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class OrderSimpleDto {
+    private Long orderId;
+    private String orderNumber;
+    private OrderStatus orderStatus;
+    private LocalDateTime orderDateTime;
+    private int totalAmount; // 최종 결제 금액
+    /** 대표 상품명  */
+    private String orderTitle;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/RefundAvailableItemResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/RefundAvailableItemResponseDto.java
@@ -1,0 +1,17 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RefundAvailableItemResponseDto {
+    private Long orderItemId;
+    private Long bookId;
+    private String bookTitle;
+    private int orderedQuantity;
+    private int alreadyReturnedQuantity;
+    private int returnableQuantity; // ordered - alreadyReturned
+    private boolean activeRefundExists;
+    private boolean refundable; // 정책/상태상 가능한지(예: 수량 0이면 false)
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/RefundItemResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/RefundItemResponseDto.java
@@ -1,0 +1,17 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefundItemResponseDto {
+    private Long refundItemId;
+    private Long orderItemId; // 원 주문 항목 ID
+    private String bookTitle;
+    private int refundQuantity;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/RefundResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/RefundResponseDto.java
@@ -1,0 +1,27 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 반품 신청, 조회, 상태 변경 시 사용
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefundResponseDto {
+    private Long refundId;
+    private Long orderId;
+    private String refundReason;
+    private String refundReasonDetail; // 반품 사유 상세 내용
+    private String refundStatus; // RefundStatus Enum의 설명 필드
+    private LocalDateTime refundDatetime;
+
+    // 반품 항목 리스트
+    private List<RefundItemResponseDto> refundItems;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/RefundSearchCondition.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/RefundSearchCondition.java
@@ -1,0 +1,30 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class RefundSearchCondition {
+    private Integer status;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    private Long userId;
+    private String userKeyword;
+    private String orderNumber;
+
+    // 기본값 true 설정(기존 코드에 defaultValue="true"
+    private boolean includeGuest = true;
+
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/UserAddressResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/UserAddressResponseDto.java
@@ -1,0 +1,11 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+public record UserAddressResponseDto(Long addressId,
+                                     String userAddressName,
+                                     String recipient,
+                                     String phone,
+                                     String zipCode,
+                                     String userAddress,
+                                     String userAddressDetail,
+                                     boolean isDefault) {
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/WrappingPaperResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/WrappingPaperResponseDto.java
@@ -1,0 +1,17 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WrappingPaperResponseDto {
+    private Long wrappingPaperId;
+    private String wrappingPaperName;
+    private int wrappingPaperPrice;
+    private String wrappingPaperPath;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/WrappingPaperSimpleResponseDto.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/response/WrappingPaperSimpleResponseDto.java
@@ -1,0 +1,19 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 포장지 목록 조회 시 사용(사용자 확인용)
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WrappingPaperSimpleResponseDto {
+    private Long wrappingPaperId;
+    private String wrappingPaperName;
+    private int wrappingPaperPrice;
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/status/OrderItemStatus.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/status/OrderItemStatus.java
@@ -1,0 +1,31 @@
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.status;
+
+public enum OrderItemStatus {
+    PREPARING(0, "상품 준비중"),
+    SHIPPED(1, "출고 완료"),
+    OUT_OF_STOCK_CANCELED(2, "품절 취소"),
+    PENDING(3, "주문 대기"),
+    ORDER_COMPLETE(4, "주문 완료"),
+    ORDER_CANCELED(5, "주문 취소"),
+    DELIVERED(6, "배송 완료"),
+    USED(7, "사용 완료"),
+    RETURN_REQUESTED(8, "반품 요청중"),
+    RETURN_COMPLETED(9, "반품 완료");
+
+    private final int code;
+    private final String description;
+
+    OrderItemStatus(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public int getCode() {
+        return code;
+    }
+    public String getDescription() {
+        return description;
+    }
+
+
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/status/OrderStatus.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/orderDto/status/OrderStatus.java
@@ -1,4 +1,4 @@
-package com.nhnacademy.book2onandonfrontservice.dto.orderDto;
+package com.nhnacademy.book2onandonfrontservice.dto.orderDto.status;
 
 
 public enum OrderStatus {

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/paymentDto/request/CommonConfirmRequest.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/paymentDto/request/CommonConfirmRequest.java
@@ -1,0 +1,15 @@
+package com.nhnacademy.book2onandonfrontservice.dto.paymentDto.request;
+
+public record CommonConfirmRequest(String orderId,
+                                   String paymentKey,
+                                   Integer amount) {
+
+    // 토스 응답 변환
+    public TossConfirmRequest toTossConfirmRequest(){
+        return new TossConfirmRequest(
+                this.orderId,
+                this.paymentKey,
+                this.amount
+        );
+    }
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/paymentDto/request/TossConfirmRequest.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/paymentDto/request/TossConfirmRequest.java
@@ -1,0 +1,6 @@
+package com.nhnacademy.book2onandonfrontservice.dto.paymentDto.request;
+
+public record TossConfirmRequest(String orderId,
+                                 String paymentKey,
+                                 Integer amount) {
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/paymentDto/response/PaymentCancelResponse.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/paymentDto/response/PaymentCancelResponse.java
@@ -1,0 +1,9 @@
+package com.nhnacademy.book2onandonfrontservice.dto.paymentDto.response;
+
+import java.time.LocalDateTime;
+
+public record PaymentCancelResponse(String paymentKey,
+                                    Integer cancelAmount,
+                                    String cancelReason,
+                                    LocalDateTime canceledAt) {
+}

--- a/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/paymentDto/response/PaymentResponse.java
+++ b/src/main/java/com/nhnacademy/book2onandonfrontservice/dto/paymentDto/response/PaymentResponse.java
@@ -1,0 +1,15 @@
+package com.nhnacademy.book2onandonfrontservice.dto.paymentDto.response;
+
+import java.time.LocalDateTime;
+
+public record PaymentResponse(String paymentKey,
+                              String orderNumber,
+                              Integer totalAmount,
+                              String paymentMethod,
+                              String paymentProvider,
+                              String paymentStatus,
+                              LocalDateTime paymentCreatedAt,
+                              String paymentReceiptUrl,
+                              Integer refundAmount,
+                              List<PaymentCancelResponse> paymentCancelResponseList) {
+}


### PR DESCRIPTION
## 🔀 PR 개요

Gateway를 통해 order-payment-service와 통신하는 Feign Client 인터페이스들을 구현했습니다. 주문, 반품(회원/비회원/관리자), 포장지 관리 기능을 포함합니다.

---

## 📄 변경 사항

어떤 부분이 수정/추가/삭제되었는지 구체적으로 기술해 주세요.

- [x] 새로운 기능 추가 (✨ Feature)
- [ ] 버그 수정 (🐞 BugFix)
- [ ] 코드 리팩토링 (🔧 Refactor)
- [ ] 문서 수정 (📝 Docs)
- [ ] 테스트 코드 추가 (🧪 Test)
- [ ] 배포 관련 (🚀 Deploy)
- [ ] 기타 설정 변경 (🧰 Setting)

- OrderUserClient: 주문 준비, 생성, 상세 조회, 취소 (Header: X-User-Id 처리)

- RefundUserClient: 회원 반품 신청/취소/목록 조회 (백엔드 URL 변경 반영)

- RefundGuestClient: 비회원 반품 신청/취소 (비밀번호 검증 파라미터 처리)

- RefundAdminClient: 관리자 반품 검색 (DTO -> @SpringQueryMap 쿼리 파라미터 변환 적용)

- WrappingPaperClient / WrappingPaperAdminClient: 포장지 조회 및 CRUD 구현

ResponseEntity 제거: 불필요한 래핑을 제거하고 DTO를 직접 반환받도록 하여 비즈니스 로직 가독성 향상.

URL 최적화 반영: 백엔드의 RefundUserController 리팩토링 사항을 반영하여, 내 반품 목록 조회 시 orderId 없이 호출하도록 구현 (/api/orders/refunds/my-list).

DTO 매핑: 백엔드 API 스펙에 맞춘 Request/Response DTO 구조화.

---

## 💡 변경 이유

프론트엔드 컨트롤러에서 주문 및 결제 관련 비즈니스 로직을 수행하기 위해 백엔드 API와의 통신 인터페이스가 필요했습니다.

관리자 검색 조건(RefundSearchCondition) 등 복잡한 파라미터 처리를 Feign Client에서 깔끔하게 추상화했습니다.

---


## 🧪 테스트 방법

- 로컬 환경에서 Gateway 및 Backend Service를 구동.

- Front Service에서 각 Client 메서드를 호출하는 단위 테스트 또는 통합 테스트 실행.

- 특히 회원 반품 목록 조회 시 orderId 파라미터 없이 정상적으로 데이터를 받아오는지 확인.
